### PR TITLE
Fix torch.no_grad

### DIFF
--- a/nr3d_lib/models/fields/nerf/lotd_nerf.py
+++ b/nr3d_lib/models/fields/nerf/lotd_nerf.py
@@ -166,7 +166,7 @@ class LoTDNeRF(ModelMixin, nn.Module):
         sigma = self.density_activation(output[..., 0])
         return dict(sigma=sigma)
     
-    @torch.no_grad
+    @torch.no_grad()
     def query_density(self, x: torch.Tensor):
         # NOTE: x must be in range [-1,1]
         h = self.encoding(x)


### PR DESCRIPTION
`torch.no_grad` needs to be instantiated with parenthesis to function as a decorator (also works for PyTorch 2.1 and later)